### PR TITLE
Update README to use autogen.sh - generates more generally working setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ You need to have **chan** [repo](https://github.com/tylertreat/chan) and **HdrHi
 
 ## Installing **chan**
 ```
-autoconf
+./autogen.sh
 ./configure
 sudo make install
 ```


### PR DESCRIPTION
With this, the build (esp for chan) works as documented on Fedora30